### PR TITLE
Add search filtering with stemming

### DIFF
--- a/__tests__/resolvers/utils/mediaUtils.integration.test.js
+++ b/__tests__/resolvers/utils/mediaUtils.integration.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it, jest } from '@jest/globals';
-import { getMediaKeywords, performFilter, performPagination, performSorting } from '../../../src/resolvers/utils/mediaUtils';
+import { extractKeywords, getMediaKeywords, performFilter, performPagination, performSorting } from '../../../src/resolvers/utils/mediaUtils';
 
 describe('mediaUtils.js integration tests', () => {
     describe('getMediaKeywords', () => {
@@ -11,7 +11,7 @@ describe('mediaUtils.js integration tests', () => {
 
             const keywords = getMediaKeywords(media);
 
-            expect(keywords).toEqual(["sample", "title", "description", "media", "content"]);
+            expect(keywords).toEqual(["sampl", "titl", "descript", "media", "content"]);
         });
 
         it('should handle empty title and description', () => {
@@ -82,6 +82,17 @@ describe('mediaUtils.js integration tests', () => {
             expect(mockQuery.where).toHaveBeenCalledWith('Media.title', 'like', `%example%`);
             expect(mockQuery.where).toHaveBeenCalledWith('Mimetype.type', 'image/png');
             expect(mockQuery.where).toHaveBeenCalledWith('Media.userId', 123);
+            expect(result).toBe(mockQuery);
+        });
+
+        it('should apply search filter to the query', () => {
+            const filter = { search: "Running quickly" };
+            const mockQuery = { where: jest.fn().mockReturnThis() };
+
+            const result = performFilter(filter, mockQuery);
+
+            const keywords = extractKeywords(filter.search);
+            expect(mockQuery.where).toHaveBeenCalledTimes(keywords.length);
             expect(result).toBe(mockQuery);
         });
 

--- a/src/resolvers/utils/mediaUtils.js
+++ b/src/resolvers/utils/mediaUtils.js
@@ -3,13 +3,18 @@
 import natural from 'natural';
 import { removeStopwords } from 'stopword';
 
-export function getMediaKeywords(media) {
-    const text = `${media.title || ''} ${media.description || ''}`.trim();
+export function extractKeywords(text) {
     if (!text) return [];
     const tokenizer = new natural.WordTokenizer();
     const tokens = tokenizer.tokenize(text.toLowerCase());
-    const keywords = removeStopwords(tokens);
-    return keywords;
+    const filtered = removeStopwords(tokens);
+    const stemmed = filtered.map((t) => natural.PorterStemmer.stem(t));
+    return Array.from(new Set(stemmed));
+}
+
+export function getMediaKeywords(media) {
+    const text = `${media.title || ''} ${media.description || ''}`.trim();
+    return extractKeywords(text);
 }
 
 export function performFilter(filter, mediaQuery) {
@@ -26,6 +31,16 @@ export function performFilter(filter, mediaQuery) {
         }
         if (filter.userId) {
             mediaQuery = mediaQuery.where('Media.userId', filter.userId);
+        }
+        if (filter.search) {
+            const keywords = extractKeywords(filter.search);
+            keywords.forEach((keyword) => {
+                mediaQuery = mediaQuery.where((builder) =>
+                    builder
+                        .orWhere('Media.title', 'like', `%${keyword}%`)
+                        .orWhere('Media.description', 'like', `%${keyword}%`),
+                );
+            });
         }
     }
     return mediaQuery;

--- a/src/types.graphql
+++ b/src/types.graphql
@@ -124,6 +124,7 @@ input MediaFilter {
     title: String
     mimetype: String
     userId: Int
+    search: String
 }
 
 input Pagination {


### PR DESCRIPTION
## Summary
- expand keyword extraction with stemming support
- enable search field on `MediaFilter`
- apply search keywords in `performFilter`
- update media utils test suite for new behavior

## Testing
- `npm test` *(fails: Could not find a working container runtime strategy)*

------
https://chatgpt.com/codex/tasks/task_e_687932db5f188329bd5323cb936846a3