### PR TITLE
Add SQLite test command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "@types/mysql": "^2.15.26",
         "@types/node": "^20.12.12",
         "babel-jest": "^29.7.0",
+        "cross-env": "^7.0.3",
         "eslint": "^9.15.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.2.1",
@@ -5800,6 +5801,25 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-inspect": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "jest --testPathIgnorePatterns=commonMocks.js --coverage --verbose",
+    "test:sqlite": "cross-env USE_TESTCONTAINERS=false npm test",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "clean": "rimraf dist",
@@ -32,6 +33,7 @@
     "eslint-plugin-prettier": "^5.2.1",
     "jest": "^29.7.0",
     "jest-mock": "^29.7.0",
+    "cross-env": "^7.0.3",
     "nodemon": "^3.1.7",
     "prettier": "^3.3.3",
     "rimraf": "^5.0.7"


### PR DESCRIPTION
## Summary
- add `test:sqlite` npm script
- install `cross-env` to support the new script

## Testing
- `npm run test:sqlite`


------
https://chatgpt.com/codex/tasks/task_e_687a62dfb1c48329acd57359ac365310