### PR TITLE
Add CI workflow for Jest tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Run unit tests
+        run: npm test
+        env:
+          USE_TESTCONTAINERS: 'false'


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run Jest unit tests on pushes and PRs

## Testing
- `USE_TESTCONTAINERS=false npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a702a5004832992fe1b9eb585ce6d